### PR TITLE
Add glitch generator to source and glitch checker to sink

### DIFF
--- a/cocotbext/uart/uart.py
+++ b/cocotbext/uart/uart.py
@@ -126,7 +126,7 @@ class UartSource:
     async def add_glitch(self, data, time, unit):
         if self._glitch_generator is not None:
             mask = next(self._glitch_generator)
-            if mask is not None:
+            if any(mask):
                 bit_val = data.value.integer
                 for k in mask:
                     if bit_val == 1:

--- a/cocotbext/uart/uart.py
+++ b/cocotbext/uart/uart.py
@@ -26,18 +26,21 @@ import logging
 
 import cocotb
 from cocotb.queue import Queue
-from cocotb.triggers import FallingEdge, Timer, First, Event
+from cocotb.triggers import Edge, FallingEdge, Timer, First, Event
 
 from .version import __version__
 
 
 class UartSource:
-    def __init__(self, data, baud=9600, bits=8, stop_bits=1, *args, **kwargs):
+    def __init__(self, data, baud=9600, bits=8, stop_bits=1, glitch_generator=None, *args, **kwargs):
         self.log = logging.getLogger(f"cocotb.{data._path}")
         self._data = data
         self._baud = baud
         self._bits = bits
         self._stop_bits = stop_bits
+        self._glitch_generator = None
+        if glitch_generator is not None:
+            self._glitch_generator = glitch_generator()
 
         self.log.info("UART source")
         self.log.info("cocotbext-uart version %s", __version__)
@@ -65,7 +68,7 @@ class UartSource:
     def _restart(self):
         if self._run_cr is not None:
             self._run_cr.kill()
-        self._run_cr = cocotb.fork(self._run(self._data, self._baud, self._bits, self._stop_bits))
+        self._run_cr = cocotb.start_soon(self._run(self._data, self._baud, self._bits, self._stop_bits))
 
     @property
     def baud(self):
@@ -120,11 +123,25 @@ class UartSource:
     async def wait(self):
         await self._idle.wait()
 
+    async def add_glitch(self, data, time, unit):
+        if self._glitch_generator is not None:
+            mask = next(self._glitch_generator)
+            if mask is not None:
+                bit_val = data.value.integer
+                for k in mask:
+                    if bit_val == 1:
+                        k = 1 if k == 0 else 0
+                    data.value = k
+                    await Timer(int(time/len(mask)),unit)
+
+    async def wait_bit(self, data, time, unit):
+        cocotb.start_soon(self.add_glitch(data,time,unit))
+        await Timer(time, unit)
+
     async def _run(self, data, baud, bits, stop_bits):
         self.active = False
 
-        bit_t = Timer(int(1e9/self.baud), 'ns')
-        stop_bit_t = Timer(int(1e9/self.baud*stop_bits), 'ns')
+        bit_t = lambda: self.wait_bit(data, int(1e9/self.baud), 'ns')
 
         while True:
             if self.empty():
@@ -138,17 +155,18 @@ class UartSource:
 
             # start bit
             data.value = 0
-            await bit_t
+            await bit_t()
 
             # data bits
             for k in range(self.bits):
                 data.value = b & 1
                 b >>= 1
-                await bit_t
+                await bit_t()
 
             # stop bit
             data.value = 1
-            await stop_bit_t
+            for _ in range(self.stop_bits):
+                await bit_t()
 
 
 class UartSink:
@@ -182,7 +200,7 @@ class UartSink:
     def _restart(self):
         if self._run_cr is not None:
             self._run_cr.kill()
-        self._run_cr = cocotb.fork(self._run(self._data, self._baud, self._bits, self._stop_bits))
+        self._run_cr = cocotb.start_soon(self._run(self._data, self._baud, self._bits, self._stop_bits))
 
     @property
     def baud(self):
@@ -250,6 +268,19 @@ class UartSink:
         else:
             await self.sync.wait()
 
+    async def assert_hold(self, signal):
+        await Edge(signal)
+        assert False, "Unexpected transition"
+
+    async def check_bits(self, period, units, signal, bits):
+        window = int(period*0.01)
+        for l in range(bits):
+            await Timer(window,units)
+            check_coro = cocotb.start_soon(self.assert_hold(signal))
+            await Timer(period-(2*window),units)
+            check_coro.kill()
+            await Timer(window,units)
+
     async def _run(self, data, baud, bits, stop_bits):
         self.active = False
 
@@ -259,6 +290,8 @@ class UartSink:
 
         while True:
             await FallingEdge(data)
+
+            cocotb.start_soon(self.check_bits(int(1e9/self.baud), 'ns', data, bits+1+stop_bits))
 
             self.active = True
 

--- a/cocotbext/uart/uart.py
+++ b/cocotbext/uart/uart.py
@@ -230,10 +230,17 @@ class UartSink:
         self._restart()
 
     async def read(self, count=-1):
-        while self.empty():
-            self.sync.clear()
-            await self.sync.wait()
-        return self.read_nowait(count)
+        if count < 0:
+            count = self.queue.qsize()
+            if count == 0:
+                count = 1
+        if self.bits == 8:
+            data = bytearray()
+        else:
+            data = []
+        for k in range(count):
+            data.append(await self.queue.get())
+        return data
 
     def read_nowait(self, count=-1):
         if count < 0:

--- a/tests/uart/test_uart.py
+++ b/tests/uart/test_uart.py
@@ -43,8 +43,12 @@ class TB:
         self.log = logging.getLogger("cocotb.tb")
         self.log.setLevel(logging.DEBUG)
 
+        enable_check_bits = False
+        if glitch_generator is not None:
+            enable_check_bits = True
+
         self.source = UartSource(dut.data, baud=115200, glitch_generator=glitch_generator)
-        self.sink = UartSink(dut.data, baud=115200)
+        self.sink = UartSink(dut.data, baud=115200, enable_check_bits=enable_check_bits)
 
 
 async def run_test(dut, payload_lengths=None, payload_data=None, glitch_generator=None):

--- a/tests/uart/test_uart.py
+++ b/tests/uart/test_uart.py
@@ -87,7 +87,7 @@ def glitch_gen():
     while True:
         rand1 = next(rand_gen)
         rand2 = next(rand_gen)
-        mask = None
+        mask = [0]*mask_size
         if rand1 > 220:
             t = int(10*(rand2/255))
             mask = [1 if i == t else 0 for i in range(mask_size)]

--- a/tests/uart/test_uart.py
+++ b/tests/uart/test_uart.py
@@ -37,19 +37,19 @@ from cocotbext.uart import UartSource, UartSink
 
 
 class TB:
-    def __init__(self, dut):
+    def __init__(self, dut, glitch_generator):
         self.dut = dut
 
         self.log = logging.getLogger("cocotb.tb")
         self.log.setLevel(logging.DEBUG)
 
-        self.source = UartSource(dut.data, baud=115200)
+        self.source = UartSource(dut.data, baud=115200, glitch_generator=glitch_generator)
         self.sink = UartSink(dut.data, baud=115200)
 
 
-async def run_test(dut, payload_lengths=None, payload_data=None):
+async def run_test(dut, payload_lengths=None, payload_data=None, glitch_generator=None):
 
-    tb = TB(dut)
+    tb = TB(dut, glitch_generator)
 
     await Timer(10, 'us')
 
@@ -68,6 +68,9 @@ async def run_test(dut, payload_lengths=None, payload_data=None):
 
         await Timer(100, 'us')
 
+@cocotb.test(expect_fail=True)
+async def run_glitch_test(dut):
+    await run_test(dut,size_list,incrementing_payload,glitch_gen)
 
 def prbs31(state=0x7fffffff):
     while True:
@@ -78,6 +81,17 @@ def prbs31(state=0x7fffffff):
                 state = (state & 0x3fffffff) << 1
         yield state & 0xff
 
+def glitch_gen():
+    mask_size = 10
+    rand_gen = prbs31()
+    while True:
+        rand1 = next(rand_gen)
+        rand2 = next(rand_gen)
+        mask = None
+        if rand1 > 220:
+            t = int(10*(rand2/255))
+            mask = [1 if i == t else 0 for i in range(mask_size)]
+        yield mask
 
 def size_list():
     return list(range(1, 16)) + [128]


### PR DESCRIPTION
Hi,
I added an assertion to the sink that fails when there is a transition in the middle of a bit and added glitch_generator parameter to source that allows insert glitches during bit transmission.
You can check the run_glitch_test test for usage example.