### PR TITLE
Update to run with cocotb 1.72

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-20.04
     
     strategy:
-      fail-fast: false # So that one fail doesn't stop remaining tests
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false # So that one fail doesn't stop remaining tests
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -12,10 +12,10 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -9,7 +9,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
-    steps:
+    steps: 
     - uses: actions/checkout@v1
 
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Python ${{matrix.python-version}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     
     strategy:
       matrix:

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -8,8 +8,9 @@ jobs:
     runs-on: ubuntu-20.04
     
     strategy:
+      fail-fast: false # So that one fail doesn't stop remaining tests
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -9,7 +9,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -11,11 +11,11 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
-    steps: 
-    - uses: actions/checkout@v1
+    steps:
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -9,7 +9,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -9,7 +9,7 @@ jobs:
     
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ To use these modules, import the one you need and connect it to the DUT:
 
 To send data into a design with a `UartSource`, call `write()` or `write_nowait()`.  Accepted data types are iterables of ints, including lists, bytes, bytearrays, etc.  Optionally, call `wait()` to wait for the transmit operation to complete.  Example:
 
-    await uart_source.send(b'test data')
+    await uart_source.write(b'test data')
     # wait for operation to complete (optional)
     await uart_source.wait()
 
 To receive data with a `UartSink`, call `read()` or `read_nowait()`.  Optionally call `wait()` to wait for new receive data.  `read()` will block until at least 1 data byte is available.  Both `read()` and `read_nowait()` will return up to _count_ bytes from the receive queue, or the entire contents of the receive queue if not specified.
 
-    data = await uart_sink.recv()
+    data = await uart_sink.read()
 
 #### Constructor parameters:
 

--- a/cocotbext/uart/uart.py
+++ b/cocotbext/uart/uart.py
@@ -65,7 +65,7 @@ class UartSource:
     def _restart(self):
         if self._run_cr is not None:
             self._run_cr.kill()
-        self._run_cr = cocotb.fork(self._run(self._data, self._baud, self._bits, self._stop_bits))
+        self._run_cr = cocotb.start_soon(self._run(self._data, self._baud, self._bits, self._stop_bits))
 
     @property
     def baud(self):
@@ -182,7 +182,7 @@ class UartSink:
     def _restart(self):
         if self._run_cr is not None:
             self._run_cr.kill()
-        self._run_cr = cocotb.fork(self._run(self._data, self._baud, self._bits, self._stop_bits))
+        self._run_cr = cocotb.start_soon(self._run(self._data, self._baud, self._bits, self._stop_bits))
 
     @property
     def baud(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 
 [options]
 packages = find_namespace:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     cocotb
 
@@ -46,16 +46,14 @@ addopts =
 
 # tox configuration
 [tox:tox]
-envlist = py36, py37, py38, py39, py310
+envlist = py37, py38, py39, py310
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311
 
 [testenv]
 setenv =

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,14 +46,16 @@ addopts =
 
 # tox configuration
 [tox:tox]
-envlist = py37, py38, py39, py310
+envlist = py38, py39, py310, py311, py312, py313
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312S
+    3.13: py313
 
 [testenv]
 setenv =

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ addopts =
 
 # tox configuration
 [tox:tox]
-envlist = py37, py38, py39, py310
+envlist = py37, py38, py39, py310, py311, py312, py313
 
 [gh-actions]
 python =
@@ -54,6 +54,9 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312S
+    3.13: py313
 
 [testenv]
 setenv =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # package information
 [metadata]
-name = cocotbext-uart
+name = cocotbext_uart
 version = attr: cocotbext.uart.version.__version__
 description = UART modules for cocotb
 keywords = uart, cocotb
@@ -46,16 +46,14 @@ addopts =
 
 # tox configuration
 [tox:tox]
-envlist = py38, py39, py310, py311, py312, py313
+envlist = py37, py38, py39, py310
 
 [gh-actions]
 python =
+    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311
-    3.12: py312S
-    3.13: py313
 
 [testenv]
 setenv =

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ addopts =
 
 # tox configuration
 [tox:tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, py310
 
 [gh-actions]
 python =
@@ -54,6 +54,8 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
 setenv =

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,11 +46,10 @@ addopts =
 
 # tox configuration
 [tox:tox]
-envlist = py37, py38, py39, py310, py311, py312, py313
+envlist = py38, py39, py310, py311, py312, py313
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ commands =
     pytest --cov=cocotbext --cov=tests --cov-branch -n auto
     bash -c 'find . -type f -name "\.coverage" | xargs coverage combine --append'
 
-whitelist_externals =
+allowlist_externals =
     bash
 
 # combine if paths are different


### PR DESCRIPTION
Hi There

I was looking at this code, and while it was working, there were a few updates required to make it play with the most up to date version of cocotb (1.7.2).  I had a little fiddliness getting my actions working first.

- [Change cocotb.fork (which is being deprecated) to cocotb.start_soon](https://github.com/alexforencich/cocotbext-uart/commit/c3583b9b0112ba79e95ee2b9d8bb36a86f7f8a68)
- Update actions revs (checkout@v3, setup-python@v4)
- Add Python 3.10
- Remove Python 3.6
- Update README example code ([send -> write ; recv -> read](https://github.com/alexforencich/cocotbext-uart/commit/4e37638930d55e72230072664894ee1657096021))
